### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-preview-storefrontcloud.yml
+++ b/.github/workflows/deploy-preview-storefrontcloud.yml
@@ -395,7 +395,7 @@ jobs:
           cd ./test-project
           yarn build
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.19
+        uses: elgohr/Publish-Docker-Github-Action@v5
         if: github.repository_owner	== 'vuestorefront'
         with:
           name: shopware-pwa-storefrontcloud-io/vue-storefront:${{ github.sha }}

--- a/.github/workflows/deploy-storefrontcloud.yml
+++ b/.github/workflows/deploy-storefrontcloud.yml
@@ -25,7 +25,7 @@ jobs:
           npx @shopware-pwa/cli@latest init --pwaHost=${{ env.PWA_HOST }} --ci --devMode
           yarn build
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: shopware-pwa-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -390,7 +390,7 @@ jobs:
           npx @shopware-pwa/cli@canary init --shopwareEndpoint=${{ env.CANARY_SW6_INSTANCE }} --shopwareAccessToken=${{ env.CANARY_SW6_INSTANCE_TOKEN }} --u ${{ secrets.SHOPWARE_ADMIN_USER }} --p ${{ secrets.SHOPWARE_ADMIN_PASSWORD }} --ci --devMode --stage canary
           yarn build
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: shopware-pwa-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore